### PR TITLE
add mruby-javascriptcore.gem

### DIFF
--- a/mruby-javascriptcore.gem
+++ b/mruby-javascriptcore.gem
@@ -1,0 +1,6 @@
+name: mruby-javascriptcore
+description: bindings to an from JavaScript for JavaScriptCore from WebKitGTK
+author: ppibburr
+website: https://github.com/ppibburr/mruby-javascriptcore
+protocol: git
+repository: https://github.com/ppibburr/mruby-javascriptcore.git


### PR DESCRIPTION
adds mruby-javascriptcore.
Bridge between Ruby and JavaScript using the JavaScriptCore API from WebKitGTK
