### PR TITLE
Remove mruby-string-enhancement as it is obsolete.

### DIFF
--- a/mruby-string-enhancement.gem
+++ b/mruby-string-enhancement.gem
@@ -1,6 +1,0 @@
-name: mruby-string-enhancement
-description: String class enhancement (adding methods that not specified by ISO Ruby method)
-author: monaka and others
-website: https://github.com/monaka/mruby-string-enhancement
-protocol: git
-repository: https://github.com/monaka/mruby-string-enhancement.git


### PR DESCRIPTION
It's obsolete. He can use mruby-string-ext (bundled gem) instead.
