### PR TITLE
remove mruby-core-ext gem

### DIFF
--- a/mruby-core-ext.gem
+++ b/mruby-core-ext.gem
@@ -1,6 +1,0 @@
-name: mruby-core-ext
-description: MRuby Core Extensions
-author: skandhas 
-website: https://github.com/skandhas/mruby-core-ext 
-protocol: git
-repository: https://github.com/skandhas/mruby-core-ext.git 


### PR DESCRIPTION
The methods already exists in _mruby/mrbgems_.
