### PR TITLE
Add matrix library

### DIFF
--- a/mruby-matrix.gem
+++ b/mruby-matrix.gem
@@ -1,0 +1,6 @@
+name: mruby-matrix
+description: Matrix and vector library
+author: listrophy
+website: https://github.com/listrophy/mruby-matrix
+protocol: git
+repository: https://github.com/listrophy/mruby-matrix.git


### PR DESCRIPTION
A port of the MRI `matrix` library, minus coercion and decomposition.