### PR TITLE
streamline naming of host-stats gem

### DIFF
--- a/mruby-host-stats.gem
+++ b/mruby-host-stats.gem
@@ -1,4 +1,4 @@
-name: host-stats
+name: mruby-host-stats
 description: library to gather stats on running system (cpu, memory, ...).
 author: Julien Ammous
 website: https://github.com/schmurfy/host-stats


### PR DESCRIPTION
I could convince the maintainer of the early host-stats mgem to streamline his name (https://github.com/schmurfy/host-stats/commit/6319767b2f031dd15cb22b503aa6ded671670ee0). I know it is a little bit pedantic but I always fall over this single gem when I browse the available mgems.