### PR TITLE
Add `repooption` directive to mruby-ipvs.gem

### DIFF
--- a/mruby-ipvs.gem
+++ b/mruby-ipvs.gem
@@ -4,3 +4,4 @@ author: YOSHIKAWA Ryota
 website: https://github.com/rrreeeyyy/mruby-ipvs
 protocol: git
 repository: https://github.com/rrreeeyyy/mruby-ipvs
+repooptions: --recursive


### PR DESCRIPTION
I found `repooptions` directive in mgem!
So I can use `mgem add` and `mgem config default` when install process with `--recursive` option.