### PR TITLE
Add mruby-open3

### DIFF
--- a/mruby-open3.gem
+++ b/mruby-open3.gem
@@ -1,0 +1,6 @@
+name: mruby-open3
+description: Popen, but with stderr, too
+author: Takashi Kokubun
+website: https://github.com/k0kubun/mruby-open3
+protocol: git
+repository: https://github.com/k0kubun/mruby-open3.git


### PR DESCRIPTION
Added mruby-open3, which is mrbgem version of open3 in Ruby.
https://github.com/k0kubun/mruby-open3