### PR TITLE
Refer forked version of mruby-yaml

### DIFF
--- a/mruby-yaml.gem
+++ b/mruby-yaml.gem
@@ -1,6 +1,6 @@
 name: mruby-yaml
 description: YAML parser and emitter
 author: Andrew Belt
-website: https://github.com/AndrewBelt/mruby-yaml
+website: https://github.com/hone/mruby-yaml
 protocol: git
-repository: https://github.com/AndrewBelt/mruby-yaml.git
+repository: https://github.com/hone/mruby-yaml.git


### PR DESCRIPTION
Hi, it seems that https://github.com/AndrewBelt/mruby-yaml is not maintained.
How about refer forked version of mruby-yaml? https://github.com/hone/mruby-yaml
See also https://github.com/hone/mruby-cli/issues/50#i