### PR TITLE
Rename mruby-table-generator -> mruby-terminal-table

### DIFF
--- a/mruby-terminal-table.gem
+++ b/mruby-terminal-table.gem
@@ -1,4 +1,4 @@
-name: mruby-table-generator
+name: mruby-terminal-table
 description: A fast and simple, yet feature rich ASCII table generator
 author: katzer
 website: https://github.com/appPlant/mruby-terminal-table


### PR DESCRIPTION
My previous PR (038eae7) contained a wrong gem name.