### PR TITLE
Add mruby-seccomp gem info

### DIFF
--- a/mruby-seccomp.gem
+++ b/mruby-seccomp.gem
@@ -1,0 +1,6 @@
+name: mruby-seccomp
+description: libseccomp wrapper for mruby
+author: Uchio Kondo
+website: https://github.com/haconiwa/mruby-seccomp
+protocol: git
+repository: https://github.com/haconiwa/mruby-seccomp.git


### PR DESCRIPTION
Hi! I have implemented mruby's libseccomp wrapper as [mruby-seccomp](https://github.com/haconiwa/mruby-seccomp/#readme).

Please accept this!