### PR TITLE
add mruby-r3

### DIFF
--- a/mruby-r3.gem
+++ b/mruby-r3.gem
@@ -1,0 +1,6 @@
+name: mruby-r3
+description: mruby binding for libr3 (path dispatching library)
+author: katzer
+website: https://github.com/katzer/mruby-r3
+protocol: git
+repository: https://github.com/katzer/mruby-r3.git


### PR DESCRIPTION
Binding for [lib3r][r3], a high-performance path dispatching library.

```ruby
tree = R3::Tree.new.tap do |t|
    t << '/users/{user_id}/feeds/{feed_id}'
    t.compile
end

tree.match '/users/1/feeds/2'
# => { user_id: '1', feed_id: '2' }
```

[r3]: https://github.com/c9s/r3