### PR TITLE
Add mruby-process2

### DIFF
--- a/mruby-process2.gem
+++ b/mruby-process2.gem
@@ -3,4 +3,4 @@ description: Implementation of the Ruby 2.4.1 Core Library Process for mruby.
 author: katzer
 website: https://github.com/appPlant/mruby-process
 protocol: git
-repository: https://github.com/appPlant/mruby-process.git
+repository: https://github.com/appPlant/mruby-process.git#windows

--- a/mruby-process2.gem
+++ b/mruby-process2.gem
@@ -3,4 +3,4 @@ description: Implementation of the Ruby 2.4.1 Core Library Process for mruby.
 author: katzer
 website: https://github.com/appPlant/mruby-process
 protocol: git
-repository: https://github.com/appPlant/mruby-process.git#windows
+repository: https://github.com/appPlant/mruby-process.git

--- a/mruby-process2.gem
+++ b/mruby-process2.gem
@@ -1,0 +1,6 @@
+name: mruby-process2
+description: Implementation of the Ruby 2.4.1 Core Library Process for mruby.
+author: katzer
+website: https://github.com/appPlant/mruby-process
+protocol: git
+repository: https://github.com/appPlant/mruby-process.git


### PR DESCRIPTION
A fork of mruby-process with feature complete support for linux/mac/windows platforms.
I add here as the [PR](https://github.com/iij/mruby-process/pull/11) shows to update.

~As the default branch is `windows`, is there a explicit way to define that in the .mgem file?~