### PR TITLE
Delete mruby-io gem

### DIFF
--- a/mruby-io.gem
+++ b/mruby-io.gem
@@ -1,6 +1,0 @@
-name: mruby-io
-description: IO, File class implementation
-author: iij
-website: https://github.com/iij/mruby-io
-protocol: git
-repository: https://github.com/iij/mruby-io.git


### PR DESCRIPTION
Since it became a bundled mrbgem, we no longer need to list this in mgem-list.