### PR TITLE
Delete mruby-socket.gem

### DIFF
--- a/mruby-socket.gem
+++ b/mruby-socket.gem
@@ -1,8 +1,0 @@
-name: mruby-socket
-description: Socket library for mruby
-author: iij
-website: https://github.com/iij/mruby-socket
-protocol: git
-repository: https://github.com/iij/mruby-socket.git
-dependencies:
-- mruby-io


### PR DESCRIPTION
Since it became a bundled mrbgem, we no longer need to list this in mgem-list.