### PR TITLE
Delete mruby-pack.gem

### DIFF
--- a/mruby-pack.gem
+++ b/mruby-pack.gem
@@ -1,6 +1,0 @@
-name: mruby-pack
-description: Array#pack implementation
-author: Internet Initiative Japan., Inc.
-website: https://github.com/iij/mruby-pack
-protocol: git
-repository: https://github.com/iij/mruby-pack.git


### PR DESCRIPTION
Since it became a bundled mrbgem, we no longer need to list this in mgem-list.