### PR TITLE
Add mruby-gettimeofday gem

### DIFF
--- a/mruby-gettimeofday.gem
+++ b/mruby-gettimeofday.gem
@@ -1,0 +1,6 @@
+name: mruby-gettimeofday
+description: A simple wrapper of `gettimeofday(2)` for mruby
+author: mame
+website: https://github.com/mame/mruby-gettimeofday
+protocol: git
+repository: https://github.com/mame/mruby-gettimeofday.git


### PR DESCRIPTION
A simple wrapper for `gettimeofday(2)`.

I created this gem because `mruby-time` is difficult to compile with `MRB_WITHOUT_FLOAT`.  Optcarrot in mruby will use this gem instead of `Time` class.