### PR TITLE
Modify repository path of mruby-redis-cluster

### DIFF
--- a/mruby-redis-cluster.gem
+++ b/mruby-redis-cluster.gem
@@ -1,7 +1,7 @@
 name: mruby-redis-cluster
 description: Client library for Redis Cluster based on matsumotory/mruby-redis
 author: Yuki Kirii
-website: https://github.com/shiftky/mruby-redis-cluster
+website: https://github.com/yukirii/mruby-redis-cluster
 protocol: git
-repository: https://github.com/shiftky/mruby-redis-cluster.git
+repository: https://github.com/yukirii/mruby-redis-cluster.git
 license: MIT


### PR DESCRIPTION
I've changed my GitHub user name. This PR modifies the repository path of mruby-redis-cluster.