### PR TITLE
Add mruby-delegate and mruby-weakref

### DIFF
--- a/mruby-delegate.gem
+++ b/mruby-delegate.gem
@@ -1,0 +1,7 @@
+name: mruby-delegate
+description: delegate implementation for mruby
+author: dearblue
+website: https://github.com/dearblue/mruby-delegate
+protocol: git
+repository: https://github.com/dearblue/mruby-delegate.git
+license: CC0

--- a/mruby-weakref.gem
+++ b/mruby-weakref.gem
@@ -1,0 +1,7 @@
+name: mruby-weakref
+description: weakref implementation for mruby
+author: dearblue
+website: https://github.com/dearblue/mruby-weakref
+protocol: git
+repository: https://github.com/dearblue/mruby-weakref.git
+license: CC0


### PR DESCRIPTION
These are implemented by C.
And similar to CRuby's `delegate` and `weakref`.

This is inspired by [How to weakly reference a mrb_value in C++ #4479](https://github.com/mruby/mruby/issues/4479).
