### PR TITLE
Create mruby-marshal-c.gem

### DIFF
--- a/mruby-marshal-c.gem
+++ b/mruby-marshal-c.gem
@@ -1,0 +1,7 @@
+name: mruby-marshal-c
+description: Marshal module for mruby written in C-language with full object-link & symbol link support
+author: Lanza Schneider
+license: Public domain
+website: https://github.com/LanzaSchneider/mruby-marshal-c
+protocol: git
+repository: https://github.com/LanzaSchneider/mruby-marshal-c.git


### PR DESCRIPTION
Marshal module for mruby written in C, with full object-link & symbol link support