### PR TITLE
feat(CI): add GNU Aspell for extra spell checking

### DIFF
--- a/.aspell.en.pws
+++ b/.aspell.en.pws
@@ -1,0 +1,6 @@
+personal_ws-1.1 en 5
+GEMs
+PascalCaseas
+YAML
+mgem
+mruby

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,8 +10,19 @@ jobs:
       - uses: actions/checkout@v2
       - name: Check merge conflict
         run: grep "^<<<<<<< HEAD" $(git ls-files | xargs) && exit 1 || true
+  gnuaspell:
+    name: Check Spelling GNU Aspell Markdown
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: |
+          sudo apt update
+          sudo apt-get install aspell
+      - name: Run Markdown Spell Check
+        run: bash ./check-spelling.sh || exit 1
   misspell:
-    name: Check Spelling
+    name: Check Spelling Misspell All Files
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/check-spelling-single.sh
+++ b/check-spelling-single.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# prints an ordered list of spelling mistakes
+while read -r file; do
+  aspell list --lang=en --encoding=utf-8 <"$file" | sort -u
+done < <(find . -name "*.md")

--- a/check-spelling.sh
+++ b/check-spelling.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# creates a file of spelling mistakes if there are any
+errors=0
+path="tests/spelling/"
+mkdir -p "$path"
+misspelled="$path"misspelled-words.txt
+if [ -f "$misspelled" ]; then
+  rm "$misspelled"
+fi
+while read -r file; do
+  echo "$file" >>"$path"misspelled-words-temp.txt
+  aspell list --lang=en --encoding=utf-8 --personal=./.aspell.en.pws <"$file" | sort -u >>"$path"misspelled-words-temp.txt
+  if [ "$(wc -l <"$path"misspelled-words-temp.txt)" -ge 2 ]; then
+    echo >>"$path"misspelled-words-temp.txt
+    cat "$path"misspelled-words-temp.txt
+    cat "$path"misspelled-words-temp.txt >>"$path"misspelled-words.txt
+    errors=1
+  fi
+  : >"$path"misspelled-words-temp.txt
+done < <(find . -name "*.md")
+if [ -f "$path"misspelled-words-temp.txt ]; then
+  rm "$path"misspelled-words-temp.txt
+fi
+if [ "$errors" -ge 1 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
Just checking Markdown files at present.

Prints an ordered list of spelling mistakes to the terminal -> `check-spelling-single.sh`

Custom English dictionary -> `.aspell.en.pws`

![Screen Shot 2021-04-11 at 11 33 27 pm](https://user-images.githubusercontent.com/418747/114306981-10063380-9b21-11eb-8d98-9496502fee87.png)

Full Shell script so far -> `check-spelling.sh` -> runs against the dictionary.

This script runs with Actions and prints out all the spelling mistakes grouped by file.

![Screen Shot 2021-04-11 at 11 33 44 pm](https://user-images.githubusercontent.com/418747/114306963-fc5acd00-9b20-11eb-94aa-d4d176a72b1e.png)






