### PR TITLE
Add two more pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,9 @@ repos:
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
+      - id: check-vcs-permalinks
       - id: check-yaml
+      - id: detect-private-key
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: mixed-line-ending


### PR DESCRIPTION
Both hooks are from the official pre-commit repo:

https://github.com/pre-commit/pre-commit-hooks

So we have:

https://github.com/pre-commit/pre-commit-hooks#check-vcs-permalinks

https://github.com/pre-commit/pre-commit-hooks#detect-private-key