### PR TITLE
Update minimum `pre-commit` version to latest `2.18.1`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,14 @@ default_stages: [commit, push]
 default_language_version:
   # force all unspecified Python hooks to run python3
   python: python3
-minimum_pre_commit_version: '1.20.0'
+minimum_pre_commit_version: '2.18.1'
 repos:
   - repo: meta
     hooks:
       - id: identity
       - id: check-hooks-apply
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -42,7 +42,7 @@ repos:
       - id: reek
       - id: rubocop
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.1
+    rev: v2.6.2
     hooks:
       - id: prettier
         name: Run prettier


### PR DESCRIPTION
Conda, Homebrew and PyPI all have `2.18.1`

https://github.com/pre-commit/pre-commit/releases
https://pypi.org/project/pre-commit/#history
https://formulae.brew.sh/formula/pre-commit
https://anaconda.org/conda-forge/pre-commit

Also run `pre-commit autoupdate`

https://pre-commit.com/#pre-commit-autoupdate