### PR TITLE
Add two more `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,14 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: trailing-whitespace
-  # - repo: git://github.com/Lucas-C/pre-commit-hooks
-  #  rev: v1.1.9
-  #  hooks:
-  #    - id: forbid-tabs
-  #    - id: remove-tabs
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.4.2
+    hooks:
+      - id: forbid-tabs
+        exclude: ^Makefile$
+      - id: remove-tabs
+        args: [--whitespaces-count, '2']
+        exclude: ^Makefile$
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:


### PR DESCRIPTION
We already use the `Lucas-C` hooks for `tabs` in the main `mruby` repository.

https://github.com/Lucas-C/pre-commit-hooks
https://github.com/mruby/mruby/blob/92ca93c885a6e6d2facd8e9ca3dbf85ac3dce8c9/.pre-commit-config.yaml#L30