### PR TITLE
gha: remove `misspell`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,15 +14,6 @@ jobs:
           bundler: 'default'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec .check.rb
-  misspell:
-    name: Check Spelling Misspell All Files In Commit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Install
-        run: wget -O - -q https://git.io/misspell | sh -s -- -b .
-      - name: Misspell
-        run: git ls-files --empty-directory | xargs ./misspell -error
   pre-commit:
     name: Run pre-commit # https://pre-commit.com/
     runs-on: ubuntu-latest


### PR DESCRIPTION
But we still have `codespell` for spell checking

https://github.com/mruby/mgem-list/blob/2a741b2d7f65af7a99c00bc76bcfc716e88d0bdf/.pre-commit-config.yaml#L35

refs https://github.com/mruby/mruby/pull/5940