### PR TITLE
Recognize `.gem` files as YAML format

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gem linguist-language=YAML


### PR DESCRIPTION
The purpose is to enable syntax highlighting on GitHub.

---

Previously, no syntax highlighting was performed: https://github.com/mruby/mgem-list/blob/71de87c2c47a18bffa8d703d2f7ecbbc95296752/mruby-gemcut.gem

After applying this patch, it will be recognized as YAML: https://github.com/dearblue/mgem-list/blob/e8267970f8d9f5fc71d18682efc1e023753e6389/mruby-weakref.gem

Note: When viewing files from a patched branch, it appears that even files with the same name from a previous branch may be highlighted. For this reason, we are trying a different file here.
