### PR TITLE
Add pre-commit hook `markdown-link-check`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,15 @@ repos:
       - id: prettier
         name: Run prettier
         description: Format files with prettier
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.11.2
+    hooks:
+      - id: markdown-link-check
+        name: Run markdown-link-check
+        description: Checks hyperlinks in Markdown files
+        args: [-q]
+        types: [markdown]
+        files: \.(md|mdown|markdown)$
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.35.0
     hooks:


### PR DESCRIPTION
https://github.com/tcort/markdown-link-check

We already use this on `mruby`:

https://github.com/mruby/mruby/blob/5b2056efda14853ecf7107a76ee0feee451b4f34/.pre-commit-config.yaml#L60