### PR TITLE
pre-commit autoupdate; fix spelling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: identity
       - id: check-hooks-apply
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -25,7 +25,7 @@ repos:
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.1
+    rev: v1.5.4
     hooks:
       - id: forbid-tabs
         exclude: ^Makefile$
@@ -33,7 +33,7 @@ repos:
         args: [--whitespaces-count, '2']
         exclude: ^Makefile$
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.5
+    rev: v2.2.6
     hooks:
       - id: codespell
         name: Run codespell
@@ -45,7 +45,7 @@ repos:
       - id: reek
       - id: rubocop
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0
+    rev: v3.0.3
     hooks:
       - id: prettier
         name: Run prettier
@@ -60,7 +60,7 @@ repos:
         types: [markdown]
         files: \.(md|mdown|markdown)$
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.35.0
+    rev: v0.37.0
     hooks:
       - id: markdownlint
         name: Run markdownlint

--- a/mruby-crc.gem
+++ b/mruby-crc.gem
@@ -1,5 +1,5 @@
 name: mruby-crc
-description: Configurable general CRC calcurator for mruby
+description: Configurable general CRC calculator for mruby
 author: dearblue
 website: https://github.com/dearblue/mruby-crc
 protocol: git


### PR DESCRIPTION
The `codespell` hook found a spelling mistake when it was updated.

Seems it should also be fixed at:

https://github.com/dearblue/mruby-crc

@dearblue 

https://pre-commit.com/#pre-commit-autoupdate