### PR TITLE
`.editorconfig`: add documentation as comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,7 @@
-# EditorConfig is awesome: https://EditorConfig.org
+# About this file, see:
+#   Website: https://editorconfig.org/
+#   For Emacs users: https://github.com/editorconfig/editorconfig-emacs
+#   For Vim users: https://github.com/editorconfig/editorconfig-vim
 
 # top-most EditorConfig file
 root = true


### PR DESCRIPTION
Seen in:

https://github.com/mruby/mruby/blob/master/.editorconfig