### PR TITLE
Delete mruby-czmq.gem

### DIFF
--- a/mruby-czmq.gem
+++ b/mruby-czmq.gem
@@ -1,9 +1,0 @@
-name: mruby-czmq
-description: mruby bindings for czmq.
-author: Hendrik Beskow
-website: https://github.com/Asmod4n/mruby-czmq
-protocol: git
-repository: https://github.com/Asmod4n/mruby-czmq.git
-dependencies:
-- mruby-errno
-license: Apache-2


### PR DESCRIPTION
This gem is no longer maintained, i've made a archive out of it.