### PR TITLE
Delete mruby-statemachine

### DIFF
--- a/mruby-statemachine.gem
+++ b/mruby-statemachine.gem
@@ -1,7 +1,0 @@
-name: mruby-statemachine
-description: a tiny state machine for mruby
-author: Hendrik Beskow
-website: https://github.com/ascaridol/mruby-statemachine
-protocol: git
-repository: https://github.com/ascaridol/mruby-statemachine.git
-license: Apache-2


### PR DESCRIPTION
The mruby-statemachine repository is no longer available.

resolved #441