### PR TITLE
gha: pin actions workflows to hash

### DIFF
--- a/.github/workflows/check-gems.yml
+++ b/.github/workflows/check-gems.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
+          ruby-version: '3.4' # Not needed with a .ruby-version file
           bundler: 'default'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - run: bundle exec .check.rb

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # v1.300.0
         with:
           ruby-version: '3.4'
           bundler-cache: true
-      - uses: j178/prek-action@v2
+      - uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1
         with:
           extra-args: --all-files

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0
           persist-credentials: false
       - name: Lint Code Base
-        uses: super-linter/super-linter/slim@v8.6.0
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           VALIDATE_EDITORCONFIG: true
           VALIDATE_GITHUB_ACTIONS: true


### PR DESCRIPTION
Use Ruby 3.4 for the check-gems workflow

https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd

https://github.com/j178/prek-action/commit/53276d8b0d10f8b6672aa85b4588c6921d0370cc

https://github.com/ruby/setup-ruby/commit/e65c17d16e57e481586a6a5a0282698790062f92

https://github.com/super-linter/super-linter/commit/9e863354e3ff62e0727d37183162c4a88873df41