### PR TITLE
mruby-zmq: update dependencies

### DIFF
--- a/mruby-zmq.gem
+++ b/mruby-zmq.gem
@@ -6,11 +6,13 @@ protocol: git
 repository: https://github.com/zeromq/mruby-zmq.git
 dependencies:
 - mruby-errno
-- mruby-simplemsgpack
 - mruby-objectspace
 - mruby-pack
 - mruby-env
 - mruby-time
-- mruby-print
 - mruby-sprintf
+- mruby-class-ext
+- mruby-metaprog
+- mruby-string-ext
+- mruby-c-ext-helpers
 license: MPL-2.0


### PR DESCRIPTION
This change updates the outdated dependency list.
For example, mruby-print is still included in the list despite being removed in [mruby/mruby@89d83c2](https://github.com/mruby/mruby/commit/89d83c27f39ce240d9480ae62a6c250246512199)

The new list was retrieved from [mrbgem.rake of mruby-zmq](https://github.com/zeromq/mruby-zmq/blob/master/mrbgem.rake#L9-L18.).