### PR TITLE
Using Rubocop Settings to Standardize String Literals with Double Quotes

### DIFF
--- a/.check.rb
+++ b/.check.rb
@@ -1,18 +1,18 @@
 #!/usr/bin/env ruby
 
-require 'yaml'
+require "yaml"
 
 Dir.glob("#{File.dirname __FILE__}/*.gem") do |f|
   print "checking #{f}\n"
   tree = YAML.parse_file(f).transform
-  unless tree['name'] && tree['description'] && tree['author'] && tree['website'] && tree['repository']
-    raise 'invalid YAML'
+  unless tree["name"] && tree["description"] && tree["author"] && tree["website"] && tree["repository"]
+    raise "invalid YAML"
   end
-  raise 'invalid protocol' unless ['git'].include? tree['protocol'] # TODO
-  raise 'no license' unless tree['license']
+  raise "invalid protocol" unless ["git"].include? tree["protocol"] # TODO
+  raise "no license" unless tree["license"]
 
-  tree['dependencies'].to_a.each do |x|
-    raise 'invalid dependencies' unless x.is_a?(String)
+  tree["dependencies"].to_a.each do |x|
+    raise "invalid dependencies" unless x.is_a?(String)
   end
 end
 

--- a/.github/linters/.rubocop.yml
+++ b/.github/linters/.rubocop.yml
@@ -4,3 +4,9 @@ AllCops:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-gem 'yaml'
+gem "yaml"

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,14 @@
-desc 'run all pre-commit hooks against all files'
+desc "run all pre-commit hooks against all files"
 task :check do
-  sh 'pre-commit run --all-files'
+  sh "pre-commit run --all-files"
 end
 
-desc 'install the pre-commit hooks'
+desc "install the pre-commit hooks"
 task :checkinstall do
-  sh 'pre-commit install'
+  sh "pre-commit install"
 end
 
-desc 'check the pre-commit hooks for updates'
+desc "check the pre-commit hooks for updates"
 task :checkupdate do
-  sh 'pre-commit autoupdate'
+  sh "pre-commit autoupdate"
 end


### PR DESCRIPTION
When string interpolation is required, string literals must be "converted" to double quotes.
Ultimately, using double quotes consistently from the start ensures greater overall consistency.

---

I plan to enhance the `.check.rb` file.
