### PR TITLE
Improves .check.rb

### DIFF
--- a/.check.rb
+++ b/.check.rb
@@ -29,11 +29,10 @@ end
 Dir.glob("#{File.dirname __FILE__}/*.gem") do |f|
   print "checking #{f}\n"
   tree = YAML.parse_file(f).transform
-  unless tree["name"] && tree["description"] && tree["author"] && tree["website"] && tree["repository"]
-    errinfo.push "#{f}: invalid YAML"
+  %w[name description author website repository protocol license].each do |key|
+    errinfo.push "#{f}: no #{key}" unless tree[key]
   end
   errinfo.push "#{f}: invalid protocol" unless ["git"].include? tree["protocol"] # TODO
-  errinfo.push "#{f}: no license" unless tree["license"]
 
   tree["dependencies"].to_a.each do |x|
     errinfo.push "#{f}: invalid dependencies" unless x.is_a?(String)

--- a/.check.rb
+++ b/.check.rb
@@ -2,18 +2,49 @@
 
 require "yaml"
 
+errinfo = Object.new
+class << errinfo
+  def push(mesg)
+    @errors ||= []
+    @errors << mesg.to_s.sub(/\n+\z/, "")
+  end
+
+  def empty?
+    !@errors || @errors.empty?
+  end
+
+  def size
+    @errors&.size || 0
+  end
+
+  def output
+    warn <<~ERR
+
+      #{@errors&.join("\n")}
+      #{size} error(s) generated.
+    ERR
+  end
+end
+
 Dir.glob("#{File.dirname __FILE__}/*.gem") do |f|
   print "checking #{f}\n"
   tree = YAML.parse_file(f).transform
   unless tree["name"] && tree["description"] && tree["author"] && tree["website"] && tree["repository"]
-    raise "invalid YAML"
+    errinfo.push "#{f}: invalid YAML"
   end
-  raise "invalid protocol" unless ["git"].include? tree["protocol"] # TODO
-  raise "no license" unless tree["license"]
+  errinfo.push "#{f}: invalid protocol" unless ["git"].include? tree["protocol"] # TODO
+  errinfo.push "#{f}: no license" unless tree["license"]
 
   tree["dependencies"].to_a.each do |x|
-    raise "invalid dependencies" unless x.is_a?(String)
+    errinfo.push "#{f}: invalid dependencies" unless x.is_a?(String)
   end
+rescue StandardError => e
+  errinfo.push e
+end
+
+unless errinfo.empty?
+  errinfo.output
+  exit 1
 end
 
 print "gem files check OK\n"

--- a/.check.rb
+++ b/.check.rb
@@ -53,7 +53,7 @@ Dir.chdir(__dir__)
 
 entries = run_and_split_nul(%w[git ls-files -z :^*/*])
 
-print "checking project management files\n"
+puts "checking project management files"
 unless (PROJECT_FILES - entries).empty?
   errinfo.push <<~MESG
     missing files: #{(PROJECT_FILES - entries).join(" ")}
@@ -62,7 +62,7 @@ unless (PROJECT_FILES - entries).empty?
 end
 
 (entries - PROJECT_FILES).each do |f|
-  print "checking #{f}\n"
+  puts "checking #{f}"
 
   unless f.match?(/\.gem$/)
     errinfo.push <<~MESG
@@ -73,7 +73,7 @@ end
     next
   end
 
-  tree = YAML.parse_file(f).transform
+  tree = YAML.load_file(f)
   %w[name description author website repository protocol license].each do |key|
     errinfo.push "#{f}: no #{key}" unless tree[key]
   end
@@ -91,4 +91,4 @@ unless errinfo.empty?
   exit 1
 end
 
-print "gem files check OK\n"
+puts "gem files check OK"

--- a/.check.rb
+++ b/.check.rb
@@ -2,6 +2,29 @@
 
 require "yaml"
 
+# please add or remove files on the top dir for management if necessary.
+# note that files in subdirectories are not included in the scan.
+PROJECT_FILES = %w[
+  .check.rb
+  .editorconfig
+  .gitattributes
+  .gitignore
+  .pre-commit-config.yaml
+  .travis.yml
+  CONTRIBUTING.md
+  Gemfile
+  Gemfile.lock
+  Makefile
+  Rakefile
+  README.md
+].freeze
+
+$PROGRAM_NAME = File.basename($PROGRAM_NAME)
+
+def run_and_split_nul(cmd)
+  IO.popen(cmd, "rb") { |pipe| pipe.read.split("\0") }
+end
+
 errinfo = Object.new
 class << errinfo
   def push(mesg)
@@ -26,8 +49,30 @@ class << errinfo
   end
 end
 
-Dir.glob("#{File.dirname __FILE__}/*.gem") do |f|
+Dir.chdir(__dir__)
+
+entries = run_and_split_nul(%w[git ls-files -z :^*/*])
+
+print "checking project management files\n"
+unless (PROJECT_FILES - entries).empty?
+  errinfo.push <<~MESG
+    missing files: #{(PROJECT_FILES - entries).join(" ")}
+    > if you removed project management files, edit PROJECT_FILES in #{$PROGRAM_NAME} file.
+  MESG
+end
+
+(entries - PROJECT_FILES).each do |f|
   print "checking #{f}\n"
+
+  unless f.match?(/\.gem$/)
+    errinfo.push <<~MESG
+      #{f}: not a ".gem" file
+      > if you added files for mruby gem (mgem), the file extension should be changed to ".gem".
+      > if you added files for project management, add into PROJECT_FILES of #{$PROGRAM_NAME} file.
+    MESG
+    next
+  end
+
   tree = YAML.parse_file(f).transform
   %w[name description author website repository protocol license].each do |key|
     errinfo.push "#{f}: no #{key}" unless tree[key]


### PR DESCRIPTION
In summary, if there are multiple errors, they are now grouped and output at the end, and files other than ".gem" files that are not registered in `.check.rb` are now reported as errors.
