### PR TITLE
mrbgems: add mruby-gpu-narray

### DIFF
--- a/mruby-gpu-narray.gem
+++ b/mruby-gpu-narray.gem
@@ -1,0 +1,8 @@
+name: mruby-gpu-narray
+description: Numo-like N-dimensional array computed on the GPU via Vulkan Compute
+author: Yuji Teshima
+website: https://github.com/yujiteshima/mruby-gpu-narray
+protocol: git
+repository: https://github.com/yujiteshima/mruby-gpu-narray.git
+branch: main
+license: MIT


### PR DESCRIPTION
Adds mruby-gpu-narray: a Numo-like N-dimensional array for mruby, computed on the GPU via Vulkan Compute. Runs on Raspberry Pi 5 (VideoCore VII / Mesa V3DV) and on macOS (MoltenVK).

Repository: https://github.com/yujiteshima/mruby-gpu-narray